### PR TITLE
Adding support to macOS app bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 !assets/**
 !libs/**
 !src/**
+
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,18 @@ add_subdirectory(libs/rayfork)
 add_executable(${CMAKE_PROJECT_NAME} src/platform.c src/game.c)
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE glad rayfork)
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE libs/rayfork libs/sokol)
-target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC ASSETS_PATH="${CMAKE_CURRENT_SOURCE_DIR}/assets/") # This is useful to get an ASSETS_PATH in your IDE during development but you should comment this if you compile a release version and uncomment the next line
-#target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC ASSETS_PATH="my-path-to-the-assets-directory") # Uncomment this line to setup the ASSETS_PATH macro to the final assets directory when you share the game
 
 # Enable MacOS specific flags and link against it's specific libraries
 if (APPLE)
+    file(GLOB ASSETS assets/*)
+    set_property(SOURCE "${ASSETS}" PROPERTY MACOSX_PACKAGE_LOCATION "Resources/assets")
+    target_sources(${CMAKE_PROJECT_NAME} PRIVATE "${ASSETS}")
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC ASSETS_PATH="assets/")
+
     target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC "-framework Cocoa" "-framework QuartzCore" "-framework OpenGL")
     target_compile_options(${CMAKE_PROJECT_NAME} PUBLIC "-fobjc-arc" "-ObjC")
+    set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES MACOSX_BUNDLE TRUE)
+else()
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC ASSETS_PATH="${CMAKE_CURRENT_SOURCE_DIR}/assets/") # This is useful to get an ASSETS_PATH in your IDE during development but you should comment this if you compile a release version and uncomment the next line
+    #target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC ASSETS_PATH="my-path-to-the-assets-directory") # Uncomment this line to setup the ASSETS_PATH macro to the final assets directory when you share the game
 endif()

--- a/src/platform.c
+++ b/src/platform.c
@@ -16,6 +16,13 @@ static platform_input_state input_state;
 
 static void sokol_on_init(void)
 {
+#ifdef RAYFORK_PLATFORM_MACOS
+    CFURLRef url = CFBundleCopyResourcesDirectoryURL(CFBundleGetMainBundle());
+    char path[PATH_MAX];
+    if (!CFURLGetFileSystemRepresentation(url, true, (UInt8 *) path, sizeof(path)) || chdir(path) != 0)
+        exit(-1);
+    CFRelease(url);
+#endif
     gladLoadGL();
 
     game_init(RF_DEFAULT_GFX_BACKEND_INIT_DATA);


### PR DESCRIPTION
This will make it so if you are using macOS it will bundle into an application, copy the assets to the resources folder and also in the plaftorm.c change the working directory in order to load the assets properly.